### PR TITLE
make code more javascript-y and remove unncessary pseudoclass

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
-var discourse_sso = require("./index.js");
-var sso = new discourse_sso("much secret, very wow");
+var sso = require("./index.js")("much secret, very wow");
 
 var payload = "bm9uY2U9dmVyeV93b3dfbXVjaF9iYXNlNjRfc29fcXVlcnk=";
 var sig = "6648376284f212b08cc66f18fc8a8f188bcf16072944add79be71939a3c8b218";


### PR DESCRIPTION
Hey man,

So I'm using your module in my app, thanks a lot!

However, I noticed that you wrote things in a way that doesn't make too much sense. There really isn't a reason to return a pseudoclass (something that has to be `new`'d), because the object would be instantiated at most one time, which defeats the purpose of using a pseudoclass. It just leads to more clutter both your code, and my code when I use your module. Instead of just doing 

`var sso = require('discourse-sso')(SSO_SECRET);`

I have to go

```
var discourse-sso = require('discourse-sso');
var sso = new discourse-sso(SSO_SECRET);
```

All in all, the former is just a much better way of doing this

Also, I took the liberty of renaming your variables to use javascript convention of camelcasing everything. Hope you don't mind. If you do, though, let me know and I can send you another PR with the variables renamed.

I also updated the test file, and it passes the changes I made.

You'd probably want to up the version if you accept these changes.
