### PR TITLE
With permission of Johan, discourse_sso_node is now MIT licensed!

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Johan Jatko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ var userparams = {
 };
 var q = sso.buildLoginString(userparams);
 ```
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
 	"name": "discourse-sso",
 	"preferGlobal": false,
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"author": "Johan Jatko <johan@pie-studios.com>",
 	"description": "Single-sign-on helper package for Discourse",
+	"license" : "MIT",
 	"contributors": [
 		{
 			"name": "Johan Jatko",


### PR DESCRIPTION
With permission of Johan, discourse_sso_node is now MIT licensed!
- Added a LICENSE file, a license property to package.json, and a license section to the readme.
- Bumped version number from 1.0.1 to 1.0.2

References Issue https://github.com/ArmedGuy/discourse_sso_node/issues/3
